### PR TITLE
Replace 1ml call with getNodeInfo, getInfo calls

### DIFF
--- a/lnt/commands/utils/utils.py
+++ b/lnt/commands/utils/utils.py
@@ -18,6 +18,25 @@ def create_stub(ctx):
     stub = lnrpc.LightningStub(channel)
     return stub, macaroon
 
+def normalize_self_info(response):
+    return {a:getattr(response, a) for a in dir(response)[-15:]}
+
+def normalize_node_info(response):
+    return {
+            'channels': response.channels,
+            'node': {
+                'last_update': response.node.last_update,
+                'pub_key': response.node.pub_key,
+                'alias': response.node.alias,
+                'addresses': [
+                    {'network':x.network, 'addr': x.addr} for x in
+                        response.node.addresses
+                ],
+                'color': response.node.color,
+            },
+            'num_channels': response.num_channels,
+            'total_capacity': response.total_capacity,
+    }
 
 def normalize_channels(channels):
     channels_d = {

--- a/lnt/rpc/api.py
+++ b/lnt/rpc/api.py
@@ -12,10 +12,19 @@ def listChannels(ctx, active_only:bool=False):
 
     return channels
 
+def getInfo(ctx):
+    request = ln.GetInfoRequest()
+    response = ctx.stub.GetInfo(request, metadata=[('macaroon', ctx.macaroon)])
+    info = utils.normalize_self_info(response)
+
+    return info
+
 def getNodeInfo(ctx, node_key, include_channels:bool=False):
     request = ln.NodeInfoRequest(pub_key=node_key, include_channels=include_channels)
     response = ctx.stub.GetNodeInfo(request, metadata=[('macaroon', ctx.macaroon)])
-    return response # praying to baby jesus I don't need to normalize
+    node_info = utils.normalize_node_info(response)
+
+    return node_info
 
 def getChanInfo(ctx, chan_id: int):
     request = ln.ChanInfoRequest(chan_id=chan_id)


### PR DESCRIPTION
Replacing 1ml with get*info calls is a convenient way to not rely on 3rd parties and solve a persistent bug