### PR TITLE
Fixed issue where testnet was being evaluated as True incorrectly

### DIFF
--- a/lnt/commands/kill.py
+++ b/lnt/commands/kill.py
@@ -8,7 +8,7 @@ from .utils import utils
 
 
 def channel(ctx):
-    testnet = ctx.parent.parent.config['LNT'].get('testnet', False)
+    testnet = ctx.parent.parent.config['LNT'].getboolean('testnet', False)
     chan_info = getChanInfo(ctx, ctx.channel_id)
     funding_txid, output_index = chan_info['chan_point'].split(':')
 
@@ -30,12 +30,12 @@ def channel(ctx):
         else:
             click.echo("Unhandled Error: " + str(error))
         return
-    
+
     if not ctx.streaming:
         click.echo(
         "Closing Tx Confirming: {}\nView it here: https://blockstream.info{}{}"\
             .format(closing_tx, '/testnet/' if testnet else '/', closing_tx))
 
     return
-    
+
 

--- a/lnt/utils.py
+++ b/lnt/utils.py
@@ -38,9 +38,10 @@ def validate_config(config):
         raise click.ClickException("Required parameter 'Host' not found in conf")
 
     if 'testnet' in config['LNT']:
+
         try:
-            config['LNT']['testnet'] = bool(config['LNT']['testnet'])
-        except Exception:
+            config['LNT'].getboolean('testnet')
+        except ValueError:
             click.ClickException("testnet has to bool")
 
     if not passed:


### PR DESCRIPTION
conf vairable `Testnet` would sometimes be equal to `'False'`, but be evaluated as `True` since `'False'` is a valid string. 